### PR TITLE
Uses correct string for version on RSI.cs

### DIFF
--- a/Importer/RSI/Rsi.cs
+++ b/Importer/RSI/Rsi.cs
@@ -41,7 +41,7 @@ namespace Importer.RSI
         {
         }
 
-        [JsonPropertyName("name")]
+        [JsonPropertyName("version")]
         public double Version { get; set; }
 
         [JsonPropertyName("size")]


### PR DESCRIPTION
I dunno why but I can't actually direct commit this. I think it's an issue with the org perms.