### PR TITLE
Add ommitting for defaults in meta.json

### DIFF
--- a/Importer.Tests/Importer.Tests.csproj
+++ b/Importer.Tests/Importer.Tests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/Importer.Tests/RSI/RsiSaveTest.cs
+++ b/Importer.Tests/RSI/RsiSaveTest.cs
@@ -149,36 +149,36 @@ namespace Importer.Tests.RSI
                     {
                         Name = "RsiState1",
                         Directions = DirectionType.Cardinal,
-                        Delays =
+                        Delays = new List<List<float>>
                         {
-                            new List<float> { 1f },
-                            new List<float> { 1f },
-                            new List<float> { 1f },
-                            new List<float> { 1f },
+                            new() { 1f },
+                            new() { 1f },
+                            new() { 1f },
+                            new() { 1f },
                         }
                     },
                     new()
                     {
                         Name = "RsiState2",
                         Directions = DirectionType.Cardinal,
-                        Delays =
+                        Delays = new List<List<float>>
                         {
-                            new List<float> { 1f, 1f },
-                            new List<float> { 1f, 1f },
-                            new List<float> { 1f, 1f },
-                            new List<float> { 1f, 1f },
+                            new() { 1f, 1f },
+                            new() { 1f, 1f },
+                            new() { 1f, 1f },
+                            new() { 1f, 1f },
                         }
                     },
                     new()
                     {
                         Name = "RsiState3",
                         Directions = DirectionType.Cardinal,
-                        Delays =
+                        Delays = new List<List<float>>
                         {
-                            new List<float> { 1f },
-                            new List<float> { 2f },
-                            new List<float> { 2f },
-                            new List<float> { 1f },
+                            new() { 1f },
+                            new() { 2f },
+                            new() { 2f },
+                            new() { 1f },
                         }
                     }
                 }

--- a/Importer.Tests/RSI/RsiSaveTest.cs
+++ b/Importer.Tests/RSI/RsiSaveTest.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using FluentAssertions.Json;
 using Importer.Directions;
 using Importer.RSI;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Importer.Tests.RSI
@@ -19,7 +21,7 @@ namespace Importer.Tests.RSI
                 Delays = new List<List<float>>(),
                 Flags = new Dictionary<string, object>()
             };
-            var states = new List<RsiState>() {state};
+            var states = new List<RsiState>() { state };
 
             Assert.IsEmpty(states[0].Delays);
             Assert.IsEmpty(states[0].Flags);
@@ -41,10 +43,10 @@ namespace Importer.Tests.RSI
         {
             var state = new RsiState
             {
-                Delays = new List<List<float>> {new() {5}},
-                Flags = new Dictionary<string, object> {["Key"] = "Value"}
+                Delays = new List<List<float>> { new() { 5 } },
+                Flags = new Dictionary<string, object> { ["Key"] = "Value" }
             };
-            var states = new List<RsiState>() {state};
+            var states = new List<RsiState>() { state };
 
             Assert.IsNotEmpty(states[0].Delays);
             Assert.IsNotEmpty(states[0].Flags);
@@ -73,10 +75,10 @@ namespace Importer.Tests.RSI
             {
                 Name = "RsiState",
                 Directions = DirectionType.Diagonal,
-                Delays = new List<List<float>> {new() {5}},
-                Flags = new Dictionary<string, object> {["Key"] = "Value"},
+                Delays = new List<List<float>> { new() { 5 } },
+                Flags = new Dictionary<string, object> { ["Key"] = "Value" },
             };
-            var states = new List<RsiState>() {state};
+            var states = new List<RsiState>() { state };
 
             Assert.IsNotEmpty(states[0].Delays);
             Assert.IsNotEmpty(states[0].Flags);
@@ -125,6 +127,93 @@ namespace Importer.Tests.RSI
             await stream.DisposeAsync();
 
             Assert.That(firstJson, Is.EqualTo(secondJson));
+        }
+
+        [Test]
+        public async Task MinimalJsonTest()
+        {
+            var rsi = new Rsi(x: 32, y: 32)
+            {
+                Version = 5,
+                License = "License",
+                Copyright = "Copyright",
+                States = new List<RsiState>()
+                {
+                    new()
+                    {
+                        Name = "RsiState0",
+                        Directions = DirectionType.None,
+                        Delays = new List<List<float>>()
+                    },
+                    new()
+                    {
+                        Name = "RsiState1",
+                        Directions = DirectionType.Cardinal,
+                        Delays =
+                        {
+                            new List<float> { 1f },
+                            new List<float> { 1f },
+                            new List<float> { 1f },
+                            new List<float> { 1f },
+                        }
+                    },
+                    new()
+                    {
+                        Name = "RsiState2",
+                        Directions = DirectionType.Cardinal,
+                        Delays =
+                        {
+                            new List<float> { 1f, 1f },
+                            new List<float> { 1f, 1f },
+                            new List<float> { 1f, 1f },
+                            new List<float> { 1f, 1f },
+                        }
+                    },
+                    new()
+                    {
+                        Name = "RsiState3",
+                        Directions = DirectionType.Cardinal,
+                        Delays =
+                        {
+                            new List<float> { 1f },
+                            new List<float> { 2f },
+                            new List<float> { 2f },
+                            new List<float> { 1f },
+                        }
+                    }
+                }
+            };
+
+            var stream = new MemoryStream();
+            await rsi.SaveRsiToStream(stream);
+
+            var json = await new StreamReader(stream).ReadToEndAsync();
+            await stream.DisposeAsync();
+
+            var parse = JToken.Parse(json);
+
+            var states0 = parse.SelectToken("$.states[0]");
+            states0.SelectToken("name").Should().HaveValue("RsiState0");
+            states0.Should().NotHaveElement("directions");
+
+            var states1 = parse.SelectToken("$.states[1]");
+            states1.SelectToken("name").Should().HaveValue("RsiState1");
+            states1.Should().HaveElement("directions");
+            states1.Should().NotHaveElement("delays");
+
+            var states2 = parse.SelectToken("$.states[2]");
+            states2.SelectToken("name").Should().HaveValue("RsiState2");
+            states2.Should().HaveElement("directions");
+            states2.Should().HaveElement("delays");
+
+            var states3 = parse.SelectToken("$.states[3]");
+            states3.SelectToken("name").Should().HaveValue("RsiState3");
+            states3.Should().HaveElement("directions");
+            states3.Should().HaveElement("delays");
+            states3.SelectToken("delays[0]").Should().BeEquivalentTo("[]");
+            states3.SelectToken("delays[1]").Should().BeEquivalentTo("[2]");
+            states3.SelectToken("delays[2]").Should().BeEquivalentTo("[2]");
+            states3.SelectToken("delays[3]").Should().BeEquivalentTo("[]");
         }
     }
 }

--- a/Importer/Importer.csproj
+++ b/Importer/Importer.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="10.3.0" />
       <PackageReference Include="MetadataExtractor" Version="2.5.0" />
       <PackageReference Include="Microsoft.Toolkit.Diagnostics" Version="7.0.2" />

--- a/Importer/Importer.csproj
+++ b/Importer/Importer.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="10.3.0" />
       <PackageReference Include="MetadataExtractor" Version="2.5.0" />
       <PackageReference Include="Microsoft.Toolkit.Diagnostics" Version="7.0.2" />


### PR DESCRIPTION
At current mooment defaults in meta.json generation aren't omitted properly.
This PR changes the serializer to omit these unnecessary details.

As a small change, this PR introduces a few dependencies necessary for testing JSON.